### PR TITLE
Standardize packet paths to packets

### DIFF
--- a/packets/README.md
+++ b/packets/README.md
@@ -16,6 +16,6 @@ Packets are **mechanical, auditable units of work** executed through Codex skill
 - `packet_contract.template.md`: canonical contract template to copy into a packet contract file.
 
 ## Typical usage
-1) Create contract under `packet/examples/<packet_id>.json`.
+1) Create contract under `packets/examples/<packet_id>.json`.
 2) Run `packet-runner` with the contract path.
 3) Review evidence under `.codex/out/<packet_id>/`.

--- a/packets/packet_contract.template.md
+++ b/packets/packet_contract.template.md
@@ -1,9 +1,9 @@
 # Packet Contract (SSOT)
 
 This document describes the packet contract. The single source of truth for generation is
-`.codex/packet/packet_contract.template.json`.
+`.codex/packets/packet_contract.template.json`.
 
-> Copy to `packet/examples/<packet_id>.json` and fill in.
+> Copy to `packets/examples/<packet_id>.json` and fill in.
 
 ## Identity
 - packet_id: "packet-001-worktree-collab"

--- a/skills/packet-runner/RUNBOOK.md
+++ b/skills/packet-runner/RUNBOOK.md
@@ -13,5 +13,5 @@ Rerun options:
 
 ## Minimal run
 ```bash
-python tools/run_packet.py control/packet/examples/<packet_id>.json
+python tools/run_packet.py control/packets/examples/<packet_id>.json
 ```

--- a/skills/packet-runner/SKILL.md
+++ b/skills/packet-runner/SKILL.md
@@ -21,7 +21,7 @@ This skill entrypoint delegates to the canonical runner:
 
 ## Outputs (Packet-002)
 Always emits a bundle under:
-- `.codex/out/<packet_id>/...` (see `packet/README.md`)
+- `.codex/out/<packet_id>/...` (see `packets/README.md`)
 
 ## Optional GitHub issue ops
 If `contract.github.issue` is configured, the runner will:
@@ -36,5 +36,5 @@ If `contract.github.issue` is configured, the runner will:
 
 ## Minimal invocation
 ```bash
-python .codex/skills/packet-runner/scripts/run_packet.py .codex/packet/examples/packet-001-worktree-collab.json
+python .codex/skills/packet-runner/scripts/run_packet.py .codex/packets/examples/packet-001-worktree-collab.json
 ```

--- a/skills/packet-runner/skill.json
+++ b/skills/packet-runner/skill.json
@@ -8,7 +8,7 @@
     "contract_path": {
       "type": "string",
       "required": true,
-      "description": "Path to the packet contract JSON (e.g., .codex/packet/examples/packet-001-worktree-collab.json)"
+      "description": "Path to the packet contract JSON (e.g., .codex/packets/examples/packet-001-worktree-collab.json)"
     }
   }
 }

--- a/skills/packet-template/SKILL.md
+++ b/skills/packet-template/SKILL.md
@@ -5,7 +5,7 @@ description: Scaffold a packet contract example file from the SSOT template.
 
 ## Purpose
 Scaffold a new packet contract example file from the SSOT template:
-- `packet/examples/<packet_id>.json`
+- `packets/examples/<packet_id>.json`
 
 ## Inputs
 - `packet_id` (required)
@@ -13,9 +13,9 @@ Scaffold a new packet contract example file from the SSOT template:
   - Default `base_ref`: `main`
 
 ## Outputs
-- `packet/examples/<packet_id>.json`
+- `packets/examples/<packet_id>.json`
 
 ## Notes
 This skill does not execute packets; it only scaffolds the contract.
 Use `packet-runner` to execute a packet.
-SSOT templates live in `.codex/packet/`.
+SSOT templates live in `.codex/packets/`.

--- a/skills/packet-template/assets/packet_contract.template.md
+++ b/skills/packet-template/assets/packet_contract.template.md
@@ -1,5 +1,5 @@
 # Packet Contract Template (pointer)
 
 This asset is a pointer only. The single source of truth is:
-- `.codex/packet/packet_contract.template.md`
-- `.codex/packet/packet_contract.template.json`
+- `.codex/packets/packet_contract.template.md`
+- `.codex/packets/packet_contract.template.json`

--- a/skills/packet-template/scripts/new_packet.py
+++ b/skills/packet-template/scripts/new_packet.py
@@ -28,7 +28,7 @@ def plant_root() -> pathlib.Path:
 def template_path(default_root: pathlib.Path, override: str | None) -> pathlib.Path:
     if override:
         return pathlib.Path(override)
-    return default_root / "packet" / "packet_contract.template.json"
+    return default_root / "packets" / "packet_contract.template.json"
 
 
 def load_template(path: pathlib.Path) -> Dict[str, Any]:
@@ -99,7 +99,7 @@ def main(argv: list[str]) -> int:
     template = load_template(template_path(root, args.template))
     contract = build_contract(template, mapping)
 
-    out_path = root / "packet" / "examples" / f"{packet_id}.json"
+    out_path = root / "packets" / "examples" / f"{packet_id}.json"
     if out_path.exists():
         die(f"already exists: {out_path}")
 

--- a/skills/packet-template/skill.json
+++ b/skills/packet-template/skill.json
@@ -2,7 +2,7 @@
   "skill_id": "packet-template",
   "version": "0.2.0",
   "title": "Packet Template (contract example generator)",
-  "description": "Creates a new packet example contract file under packet/examples using the SSOT template.",
+  "description": "Creates a new packet example contract file under packets/examples using the SSOT template.",
   "entrypoint": "scripts/new_packet.py",
   "inputs": {
     "packet_id": {


### PR DESCRIPTION
## Summary\n- align packet-template script/docs with the repo's packets/ layout\n- update packet-runner docs and skill metadata to reference packets/\n- fix template pointers to .codex/packets/\n\n## Issue\nCloses #2