### PR TITLE
Add canonical reason codes schema and constants (v0.1)

### DIFF
--- a/schemas/gate_worker.schema.json
+++ b/schemas/gate_worker.schema.json
@@ -1,0 +1,37 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "xtrl/schemas/gate_worker.schema.json",
+  "title": "xtrl gate_worker v0.1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "generated_at_utc",
+    "decision",
+    "reason_code",
+    "facts",
+    "pointers"
+  ],
+  "properties": {
+    "schema_version": {"type": "string", "enum": ["xtrl.gate_worker/v0.1"]},
+    "generated_at_utc": {"type": "string"},
+    "tool": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "name": {"type": "string"},
+        "version": {"type": "string"}
+      }
+    },
+    "decision": {"type": "string", "enum": ["ALLOW", "DENY"]},
+    "reason_code": {"$ref": "reason_codes.schema.json"},
+    "facts": {"type": "object"},
+    "pointers": {"type": "object"}
+  },
+  "allOf": [
+    {
+      "if": {"properties": {"decision": {"const": "ALLOW"}}},
+      "then": {"properties": {"reason_code": {"const": "OK"}}}
+    }
+  ]
+}

--- a/schemas/reason_codes.schema.json
+++ b/schemas/reason_codes.schema.json
@@ -1,0 +1,21 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "xtrl/schemas/reason_codes.schema.json",
+  "title": "xtrl reason codes v0.1",
+  "type": "string",
+  "enum": [
+    "OK",
+    "NOT_IMPLEMENTED",
+    "INTERNAL_ERROR",
+
+    "SCHEMA_VALIDATION_FAILED",
+    "ACTION_NOT_FOUND",
+    "FORBIDDEN_PATH_HIT",
+    "DIFF_BUDGET_EXCEEDED",
+
+    "PATCH_APPLY_FAILED",
+    "CHECK_FAILED",
+    "STALE_BASE_REF",
+    "LOCK_UNAVAILABLE"
+  ]
+}

--- a/tools/reason_codes.py
+++ b/tools/reason_codes.py
@@ -1,0 +1,46 @@
+"""Canonical reason codes for xtrl.
+
+Single source of truth for reason-code strings used across:
+- gate_worker.json
+- linearizer replay/promotion reports
+- replay/fuzz harness reports
+
+Keep this list stable; add new codes only with schema + tests.
+"""
+
+from __future__ import annotations
+
+from enum import Enum
+from typing import Iterable, Set
+
+
+class ReasonCode(str, Enum):
+    # Success / meta
+    OK = "OK"
+    NOT_IMPLEMENTED = "NOT_IMPLEMENTED"
+    INTERNAL_ERROR = "INTERNAL_ERROR"
+
+    # Worker gate
+    SCHEMA_VALIDATION_FAILED = "SCHEMA_VALIDATION_FAILED"
+    ACTION_NOT_FOUND = "ACTION_NOT_FOUND"
+    FORBIDDEN_PATH_HIT = "FORBIDDEN_PATH_HIT"
+    DIFF_BUDGET_EXCEEDED = "DIFF_BUDGET_EXCEEDED"
+
+    # Linearizer / promotion
+    PATCH_APPLY_FAILED = "PATCH_APPLY_FAILED"
+    CHECK_FAILED = "CHECK_FAILED"
+    STALE_BASE_REF = "STALE_BASE_REF"
+    LOCK_UNAVAILABLE = "LOCK_UNAVAILABLE"
+
+
+ALL_REASON_CODES: Set[str] = {c.value for c in ReasonCode}
+
+
+def is_valid_reason_code(code: str) -> bool:
+    return code in ALL_REASON_CODES
+
+
+def require_valid_reason_codes(codes: Iterable[str]) -> None:
+    bad = [c for c in codes if c not in ALL_REASON_CODES]
+    if bad:
+        raise ValueError(f"invalid reason_code(s): {bad}")


### PR DESCRIPTION
Adds a canonical reason-code enum as both:
- JSON Schema: `schemas/reason_codes.schema.json`
- Python constants: `tools/reason_codes.py`

Also adds `schemas/gate_worker.schema.json` referencing the canonical reason codes.

Intended to unblock Phase B/C/D packets by ensuring stable reason_code strings are defined once.
